### PR TITLE
fix the text cliping issue

### DIFF
--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -102,13 +102,14 @@ function Landing() {
                             />
                         </div>
                     </div>
-                    <div className="flex flex-col items-start gap-5 w-[80vw] mt-12 md:mt-0 md:w-[20vw]">
-                        <div className="h-[130px] md:h-[130px] xl:h-[180px] 2xl:h-[180px]">
-                            <span
-                                className="type-Landing font-bold text-xl md:text-2xl xl:text-2xl 2xl:text-5xl transition-all ease-in-out h-auto xl:h-42"
-                                style={convertStyle(demoColors.darkShades)}>
+                    <div className="flex flex-col items-start gap-5 w-full md:w-[28vw] lg:w-[25vw] xl:w-[22vw] mt-12 md:mt-0">
 
-                            </span>
+
+                        <div className="min-h-[130px] md:min-h-[130px] xl:min-h-[180px] h-auto">
+                            <span
+                                className="type-Landing font-bold text-xl md:text-2xl xl:text-2xl 2xl:text-5xl transition-all ease-in-out overflow-visible break-words"
+                                style={convertStyle(demoColors.darkShades)}
+                            ></span>
                         </div>
                         <p
                             className="transition-all ease-in-out text-lg md:text-sm xl:text-lg"


### PR DESCRIPTION
This PR fixes an issue where the hero section title text was getting clipped on some devices — particularly laptops with resolutions like 1366×768, 1536×864, or Windows 125% display scaling.

The clipping happened because the title was wrapped inside a fixed-height container (h-[130px]).
When the typing animation completed, the final text height varied slightly across devices due to different font rendering and viewport sizes, causing overflow and clipping.

What I changed
Replaced the fixed height container (h-[130px]) with a responsive combination of
min-h-[130px] h-auto
so the container can grow when needed.
Added overflow-visible and break-words to the typing span to prevent hidden overflow.
Increased the width of the text container from md:w-[20vw] to more responsive values (md:w-[28vw] lg:w-[25vw] xl:w-[22vw]) so the text doesn't wrap too early.